### PR TITLE
Add fixes for `now dev`

### DIFF
--- a/now.json
+++ b/now.json
@@ -5,7 +5,7 @@
     { "src": "api/time/*.js", "use": "@now/node" },
     {
       "src": "www/package.json",
-      "use": "@now/static-build",
+      "use": "@now/static-build@canary",
       "config": { "distDir": "build" }
     }
   ],

--- a/www/package.json
+++ b/www/package.json
@@ -17,7 +17,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "now-dev": "react-scripts start",
+    "now-dev": "BROWSER=none react-scripts start",
     "now-build": "react-scripts build"
   },
   "eslintConfig": {


### PR DESCRIPTION
* Set `BROWSER=none` in the `now-dev` script. This prevents `react-scripts` from opening a web browser page to its dev server, since we want to use `now dev`'s server URL, not the one spawned by `react-scripts`.
* Use `@now/static-build@canary` builder. Currently the fix in https://github.com/zeit/now-builders/pull/499 is only published on the `canary` tag.

Related to https://github.com/zeit/now-cli/issues/2336.